### PR TITLE
Fix calldata

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -115,7 +115,7 @@ export default function Home() {
 
         let instructionSets = programsToInstructionSets (programs)
         const args = packSolution (instructionSets, mechInitPositions, operatorStates)
-        // console.log ('> useMemo: args =', args)
+        console.log ('> useMemo: args =', args)
 
         const tx = {
             contractAddress: SIMULATOR_ADDR,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -809,7 +809,10 @@ export default function Home() {
                             mounted ?
                             namespace.map((name: string,name_i: number) => {
                                 return (
-                                    <SavedSolutionElement key={`saved-solution-element-${name_i}`} name={name}
+                                    <SavedSolutionElement
+                                        key={`saved-solution-element-${name_i}`}
+                                        index={name_i}
+                                        name={name}
                                         onLoadClick={() => {
                                             const solution = getSolutionFromLocal (name)
                                             handleLoadSolutionClick (solution)
@@ -817,7 +820,6 @@ export default function Home() {
                                         onClearClick={() => {
                                             handleClearSpecificClick (name)
                                         }}
-
                                     />
                                 )
                             }):
@@ -1036,7 +1038,10 @@ export default function Home() {
                                 <div key={`row-${i}`} className={styles.grid_row}>
                                     {
                                         Array.from({length:DIM}).map ((_,j) => ( // j is x
-                                            <Tooltip title={`${j},${i}`} disableInteractive arrow>
+                                            <Tooltip
+                                                title={`${j},${i}`} disableInteractive arrow
+                                                key={`tooltip-${j}`}
+                                            >
                                                 <div>
                                                     <Unit
                                                         key={`unit-${j}-${i}`}

--- a/src/components/IconizedInstructionPanel.tsx
+++ b/src/components/IconizedInstructionPanel.tsx
@@ -46,6 +46,7 @@ const IconizedInstructionPanel = ({
                             cursor: "pointer",
                         }}
                         onClick={() => onPress(key)}
+                        key={`iconized-instruction-panel-${key_i}`}
                     >
                         <i
                             className="material-icons"

--- a/src/components/savedSolutionElement.tsx
+++ b/src/components/savedSolutionElement.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import Solution from '../types/Solution'
 
-export default function SavedSolutionElement ({ key, name, onLoadClick, onClearClick }) {
+export default function SavedSolutionElement ({ index, name, onLoadClick, onClearClick }) {
 
     const CLEAR_BUTTON_DIM = 16
 
     // render table row
     return (
-        <div style={{
+        <div
+            style={{
             position:'relative',
-            height:'35px',
-            width: '50px',
-            marginRight: '5px'
-        }}>
+                height:'35px',
+                width: '50px',
+                marginRight: '5px'
+            }}
+            key={`saved-solution-element-div-${index}`}
+        >
             <button
                 style={{
                     border: '1px solid #555555',
@@ -24,7 +27,6 @@ export default function SavedSolutionElement ({ key, name, onLoadClick, onClearC
                     right: '0',
                 }}
                 onClick={onLoadClick}
-                key={key}
             >
                 {name}
             </button>
@@ -42,7 +44,6 @@ export default function SavedSolutionElement ({ key, name, onLoadClick, onClearC
                     zIndex: '1'
                 }}
                 onClick={onClearClick}
-                key={key+'-clear'}
             >
                 {'x'}
             </button>


### PR DESCRIPTION
Right now tx calldata is computed via useMemo which depends on various React states.

Problem: if a player submits a diagram without running a simulation, the diagram's content (input tag values) does not store into the React states because no render happened, which leads to incorrect calldata.

what would be a better pattern?